### PR TITLE
Integrate Moza wheel support

### DIFF
--- a/Modules/Moza/main.py
+++ b/Modules/Moza/main.py
@@ -1,0 +1,30 @@
+from ETS2LA.Module import *
+import logging
+import struct
+import socket
+
+class Module(ETS2LAModule):
+    """Sends steering angles to a Moza wheel base over UDP."""
+    def imports(self):
+        global socket
+        import socket
+
+    def init(self):
+        self.address = ("127.0.0.1", 60400)
+        try:
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        except Exception as e:
+            logging.error(f"Failed to create UDP socket for Moza: {e}")
+            self.sock = None
+
+    def send_angle(self, angle: float) -> None:
+        if self.sock is None:
+            return
+        try:
+            data = struct.pack("f", angle)
+            self.sock.sendto(data, self.address)
+        except Exception as e:
+            logging.error(f"Failed to send angle to Moza wheel: {e}")
+
+    def run(self, angle: float):
+        self.send_angle(angle)

--- a/Plugins/Map/main.py
+++ b/Plugins/Map/main.py
@@ -72,7 +72,7 @@ class Plugin(ETS2LAPlugin):
         name="plugins.map",
         description="plugins.map.description",
         version="2.0.0",
-        modules=["SDKController", "TruckSimAPI", "Steering", "Route"],
+        modules=["SDKController", "TruckSimAPI", "Steering", "Route", "Moza"],
         tags=["Base", "Steering"],
         ui_filename="ui.py",
     )
@@ -226,10 +226,11 @@ class Plugin(ETS2LAPlugin):
             data.controller = self.modules.SDKController.SCSController()
             data.plugin = self
 
-            global api, steering
+            global api, steering, moza
             api = self.modules.TruckSimAPI
             api.TRAILER = True
             steering = self.modules.Steering
+            moza = self.modules.Moza
             steering.OFFSET = 0
             steering.SMOOTH_TIME = self.steering_smoothness
             steering.IGNORE_SMOOTH = False
@@ -328,6 +329,10 @@ class Plugin(ETS2LAPlugin):
                         steering_value = -0.95
 
                     steering.run(value=steering_value, sendToGame=data.enabled, drawLine=False)
+                    try:
+                        moza.run(steering_value * 900)
+                    except Exception:
+                        logging.exception("Failed to update Moza wheel")
                 else:
                     logging.warning("Invalid steering value received")
                     


### PR DESCRIPTION
## Summary
- add new Moza module for sending steering data via UDP
- include Moza in Map plugin modules
- initialize Moza module and send wheel angle

## Testing
- `python -m py_compile Modules/Moza/main.py Plugins/Map/main.py Modules/Steering/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850094ba584832da9155bc99c23c2c4